### PR TITLE
[FIX] Fix/travis python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - git checkout json -- orangecontrib/geo/geojson/\*.json
 
 install:
-  - pip install PyQt5
+  - pip install PyQt5==5.11.*
   - pip install Orange3
   - pip install pandas
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: false
 dist: trusty
-python: 3.5
+python: 3.6
 cache:
   apt: true
   pip: true

--- a/orangecontrib/geo/widgets/tests/test_owmap.py
+++ b/orangecontrib/geo/widgets/tests/test_owmap.py
@@ -75,8 +75,7 @@ class TestOWMap(WidgetTest):
         self.widget.map.set_marker_label('latitude')
         self.widget.map.set_marker_shape('foo')
         self.widget.map.set_marker_size('latitude')
-        self.process_events(
-            until=lambda start_time=time.clock(): time.clock() - start_time > .2)
+        self.process_events()
         self.widget.map.set_marker_color(None)
         self.widget.map.set_marker_label(None)
         self.widget.map.set_marker_shape(None)


### PR DESCRIPTION
##### Issue
Fixes falling Travis
##### Description of changes
Update Python version (Orange requires Python 3.6 or newer),
fix PyQt version (new versions lack QtWebEngineWidgets),
fix falling OWMep test (until function timeouts).
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
