### PR TITLE
OWGeoMap: automatically set lat and lon only if bouth are known

### DIFF
--- a/orangecontrib/geo/widgets/owmap.py
+++ b/orangecontrib/geo/widgets/owmap.py
@@ -809,7 +809,7 @@ class OWMap(widget.OWWidget):
             model.set_domain(domain)
 
         lat, lon = find_lat_lon(data)
-        if lat or lon:
+        if lat is not None and lon is not None:
             self._combo_lat.setCurrentIndex(-1 if lat is None else self._latlon_model.indexOf(lat))
             self._combo_lon.setCurrentIndex(-1 if lat is None else self._latlon_model.indexOf(lon))
             self.lat_attr = lat.name


### PR DESCRIPTION
##### Issue
Fixes #59
##### Description of changes
Use automatically detected latitude and longitude only if both where detected.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
