### PR TITLE
Geo map fixes

### DIFF
--- a/orangecontrib/geo/widgets/owmap.py
+++ b/orangecontrib/geo/widgets/owmap.py
@@ -268,26 +268,24 @@ class LeafletMap(WebviewWidget):
                 is_na = np.isnan(encoded_values)
                 contains_na = np.any(is_na)
 
+                used_colors = variable.colors
+                num_colors = len(used_colors)
                 # Add a NA value + gray color locally (does not change attribute properties)
                 if contains_na:
                     _values = np.append(_values, "NA")
-                    used_colors = np.vstack((variable.colors, [186, 189, 182]))
-                    legend_tt = self._legend_values(variable, range(len(_values) - 1))
-                    legend_tt.append("NA")
-                else:
-                    used_colors = variable.colors
-                    legend_tt = self._legend_values(variable, range(len(_values)))
+                    used_colors = np.vstack((variable.colors, [128, 128, 128]))
 
                 __values = encoded_values.astype(np.uint16, copy=True)
-                __values[is_na] = len(variable.colors)
+                __values[is_na] = num_colors
                 self._raw_color_values = _values[__values]  # The joke's on you
+                _values = _values[: num_colors]
                 self._scaled_color_values = __values
                 self._colorgen = ColorPaletteGenerator(len(used_colors), used_colors)
                 self._legend_colors = ['d',
-                                       legend_tt,
+                                       self._legend_values(variable, range(num_colors)),
                                        list(_values),
                                        [color_to_hex(self._colorgen.getRGB(i))
-                                        for i in range(len(_values))]]
+                                        for i in range(num_colors)]]
         finally:
             if update:
                 self.redraw_markers_overlay_image(new_image=True)

--- a/orangecontrib/geo/widgets/owmap.py
+++ b/orangecontrib/geo/widgets/owmap.py
@@ -789,6 +789,13 @@ class OWMap(widget.OWWidget):
             map.set_jittering(self.jittering)
 
         def _set_clustering():
+            self._jittering.setEnabled(not self.cluster_points)
+            self._jittering.value_label.setEnabled(not self.cluster_points)
+            if self.cluster_points:
+                self._jittering.setToolTip("Jittering is disabled when 'Cluster points' is checked")
+            else:
+                self._jittering.setToolTip(None)
+
             map.set_clustering(self.cluster_points)
 
         self._opacity_slider = gui.hSlider(

--- a/orangecontrib/geo/widgets/owmap.py
+++ b/orangecontrib/geo/widgets/owmap.py
@@ -272,7 +272,7 @@ class LeafletMap(WebviewWidget):
                 num_colors = len(used_colors)
                 # Add a NA value + gray color locally (does not change attribute properties)
                 if contains_na:
-                    _values = np.append(_values, "NA")
+                    _values = np.append(_values, "?")
                     used_colors = np.vstack((variable.colors, [128, 128, 128]))
 
                 __values = encoded_values.astype(np.uint16, copy=True)

--- a/orangecontrib/geo/widgets/tests/test_owmap.py
+++ b/orangecontrib/geo/widgets/tests/test_owmap.py
@@ -139,3 +139,12 @@ class TestOWMap(WidgetTest):
         table2 = data.Table.from_numpy(domain, x_data[[0, 1, 3]])
         self.send_signal(self.widget.Inputs.data, table2)
         self.assertTrue(len(set(self.widget.map._raw_color_values)) == 2)
+
+    def test_hide_jitter_clustering(self):
+        """ Test that jittering is disabled when 'Cluster points' is checked """
+        self.send_signal(self.widget.Inputs.data, self.data)
+        self.widget.controls.cluster_points.setChecked(False)
+        self.assertTrue(self.widget._jittering.isEnabled())
+
+        self.widget.controls.cluster_points.setChecked(True)
+        self.assertTrue(not self.widget._jittering.isEnabled())


### PR DESCRIPTION
##### Issue
Fixes #55 and (partially?) #69.

##### Description of changes
Regarding #55: prevents change of jittering and shadows its value when 'Cluster points' is checked.  

Regarding #69: plots missing values for **discrete** variables with a gray color (somewhat arbitrarily chosen, please feel free to suggest an alternative, if it does not fit the color scheme). The handling of missing values is local to this widget and does not change any of the attribute's properties.  
In a nutshell, nans get assigned a new (previously unassigned) integer, which maps to gray color.  

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
