### PR TITLE
GeoMap: failing to load tiles

### DIFF
--- a/orangecontrib/geo/widgets/owmap.py
+++ b/orangecontrib/geo/widgets/owmap.py
@@ -598,7 +598,6 @@ class ImageLoader(QObject):
             QNetworkRequest.CacheLoadControlAttribute,
             QNetworkRequest.PreferCache
         )
-        request.setAttribute(QNetworkRequest.HTTP2AllowedAttribute, True)
         request.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
         request.setMaximumRedirectsAllowed(5)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #84.

##### Description of changes
Remove HTTP2AllowedAttribute.
This is a QTBUG-61397, which is fixed in version 5.12. The old installer still comes with qt=5.9.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
