### PR TITLE
Travis: raise minimum Orange version for testing to 3.25.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 matrix:
   include:
     - python: '3.6'
-      env: ORANGE="3.25.0"
+      env: ORANGE="3.25.1"
 
     - python: '3.6'
       env: ORANGE="release"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Tests fail due to scikit-learn change which was fixed in 3.25.1

##### Description of changes
Lifting version

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
