### PR TITLE
MapViewBox: Fix zooming with trackpad; add zoom in and out on mouse clicks

### DIFF
--- a/orangecontrib/geo/widgets/owchoropleth.py
+++ b/orangecontrib/geo/widgets/owchoropleth.py
@@ -170,7 +170,8 @@ class ChoroplethItem(pg.GraphicsObject):
                    for qpoly in self.region.qpolys)
 
     def mouseClickEvent(self, ev):
-        if ev.button() == Qt.LeftButton and self.contains(ev.pos()):
+        if ev.button() == Qt.LeftButton and self.contains(ev.pos()) \
+                and not ev.double():
             self.itemClicked.emit(self.region.id)
             ev.accept()
         else:

--- a/orangecontrib/geo/widgets/plotutils.py
+++ b/orangecontrib/geo/widgets/plotutils.py
@@ -158,10 +158,16 @@ class MapViewBox(InteractiveViewBox):
             super().mouseDragEvent(ev, axis=axis)
 
     def mouseClickEvent(self, ev):
-        if ev.button() == Qt.RightButton:
-            ev.ignore()
-        else:
+        if ev.button() != Qt.RightButton and not ev.double():
             super().mouseClickEvent(ev)
+            return
+        center = self.mapToView(ev.pos())
+        if ev.double():
+            self.__zoom_level = self.__clipped_zoom(self.__zoom_level + 1)
+        else:
+            self.__zoom_level = self.__clipped_zoom(self.__zoom_level - 1)
+        self.match_zoom(center, offset=True)
+        ev.accept()
 
     def match_zoom(self, center: Point, offset=False):
         """

--- a/orangecontrib/geo/widgets/tests/test_plotutils.py
+++ b/orangecontrib/geo/widgets/tests/test_plotutils.py
@@ -63,9 +63,11 @@ class TestMapViewBox(WidgetTest):
 
         self.assertEqual(self.mvb.get_zoom(), 2)
         self.mvb.wheelEvent(mock_event)
+        self.mvb.wheelEvent(mock_event)
         self.assertEqual(self.mvb.get_zoom(), 3)
         qrect1 = self.sr.call_args[0][0]
         mock_event.accept.assert_called()
+        self.mvb.wheelEvent(mock_event)
         self.mvb.wheelEvent(mock_event)
         self.assertEqual(self.mvb.get_zoom(), 4)
         qrect2 = self.sr.call_args[0][0]
@@ -74,11 +76,14 @@ class TestMapViewBox(WidgetTest):
 
         mock_event.delta.return_value = -1
         self.mvb.wheelEvent(mock_event)
+        self.mvb.wheelEvent(mock_event)
         self.assertEqual(self.mvb.get_zoom(), 3)
         qrect3 = self.sr.call_args[0][0]
         # after zooming out the shown rectangle should be larger
         self.assertTrue(qrect3.width() > qrect2.width())
 
+        self.mvb.wheelEvent(mock_event)
+        self.mvb.wheelEvent(mock_event)
         self.mvb.wheelEvent(mock_event)
         self.mvb.wheelEvent(mock_event)
         self.assertEqual(self.mvb.get_zoom(), 2)


### PR DESCRIPTION
##### Issue

Zooming is too fast and in most cases zooming in is immediatelly followed by zooming all the way out.

The latter happens because the condition was `if ev.delta() > 0: ... else: ...` instead of `if ev.delta() > 0: ... elif ev.delta() < 0: ...`. Apparently, the zoom-in event can be followed by a number of events with delta equal to 0, which was interpreted as zooming out. :)

Fixes #140. Cmd-0 is less necessary.

##### Description of changes

- Use `np.sign(ev.delta())` (which can also equal 0)
- Use floats for zoom level, a suitable step seems to be 0.5. When using it, cast it to int.

##### Includes
- [X] Code changes
- [X] Tests
