### PR TITLE
Add Python 3.9 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2016]
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         tox_env: [py-orange-released]
         experimental: [false]
         name: [Released]
@@ -66,6 +66,22 @@ jobs:
             experimental: false
             name: Latest
 
+          - os: windows-2016
+            python-version: 3.9
+            tox_env: py-orange-latest
+            experimental: false
+            name: Latest
+          - os: macos-10.15
+            python-version: 3.9
+            tox_env: py-orange-latest
+            experimental: false
+            name: Latest
+          - os: ubuntu-18.04
+            python-version: 3.9
+            tox_env: py-orange-latest
+            experimental: false
+            name: Latest
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -86,8 +102,8 @@ jobs:
 
       - name: Upload code coverage
         if: |
-          matrix.python-version == '3.8' &&  
-          matrix.os == 'ubuntu-18.04' && 
+          matrix.python-version == '3.8' &&
+          matrix.os == 'ubuntu-18.04' &&
           matrix.tox_env == 'py-orange-released'
         run: |
           pip install codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38}-orange-{oldest, latest, released}
+    py{37,38,39}-orange-{oldest, latest, released}
 skip_missing_interpreters = true
 isolated_build = true
 


### PR DESCRIPTION
##### Issue

Fixes #141.

Orange is also tested on Python 3.9, and so should be this add-on.