### PR TITLE
Geo Transform Improvements

### DIFF
--- a/orangecontrib/geo/utils.py
+++ b/orangecontrib/geo/utils.py
@@ -10,45 +10,59 @@ LATITUDE_NAMES = ('latitude', 'lat')
 LONGITUDE_NAMES = ('longitude', 'lng', 'long', 'lon')
 
 
-def find_lat_lon(data, filter_hidden=False, fallback=True):
-    """Return inferred latitude and longitude attributes as found in the data domain"""
+def find_lat_lon(data, filter_hidden=False):
+    """
+    Infer latitude and longitude attributes from data
+
+    - If there are less than two numeric variables, return None, None
+    - If there are variables with recognized names (see LATITUDE_NAMES,
+      LONGITUDE_NAMES), return them
+    - Otherwise, if there are exactly two numeric variables
+       - if one has a matching name, the other is chosen to be the other coord
+       - if one has all values below 90 and the other has at least one above,
+        these are latitude and longitude
+       - otherwise, the first one is latitude, the other is longitude
+    - Otherwise (there are more than two variables), return a pair containing
+      the first variable twice, so the user sees a diagonal, which indicates
+      that this has to be set manually.
+    """
     assert isinstance(data, Table)
 
-    all_vars = list(chain(data.domain.variables, data.domain.metas))
+    cont_vars = (var for var in chain(data.domain.variables, data.domain.metas)
+                 if var.is_continuous)
     if filter_hidden:
-        all_vars = list(filter_visible(all_vars))
+        cont_vars = filter_visible(cont_vars)
+    cont_vars = list(cont_vars)
+
+    if len(cont_vars) < 2:
+        return None, None
 
     lat_attr = next(
-        (attr for attr in all_vars
-         if attr.is_continuous and
-         attr.name.lower().startswith(LATITUDE_NAMES)), None)
+        (attr for attr in cont_vars
+         if attr.name.lower().startswith(LATITUDE_NAMES)), None)
     lon_attr = next(
-        (attr for attr in all_vars
-         if attr.is_continuous and
-         attr.name.lower().startswith(LONGITUDE_NAMES)),
-        None)
-
-    if not fallback:
+        (attr for attr in cont_vars
+         if attr.name.lower().startswith(LONGITUDE_NAMES)), None)
+    if lat_attr and lon_attr:
         return lat_attr, lon_attr
 
-    def _all_between(vals, min, max):
-        return np.all((min <= vals) & (vals <= max))
+    def max_in_col(attr):
+        if not data:
+            return 0
+        return np.nanmax(np.abs(data.get_column_view(attr)[0].astype(float)))
 
-    if not lat_attr:
-        for attr in all_vars:
-            if attr.is_continuous:
-                values = np.nan_to_num(
-                    data.get_column_view(attr)[0].astype(float))
-                if _all_between(values, -90, 90):
-                    lat_attr = attr
+    if len(cont_vars) == 2:
+        if lat_attr is not None:
+            lon_attr = cont_vars[1 - cont_vars.index(lat_attr)]
+        elif lon_attr is not None:
+            lat_attr = cont_vars[1 - cont_vars.index(lon_attr)]
+        else:
+            for lat_attr, lon_attr in (cont_vars[::-1], cont_vars):
+                if max_in_col(lat_attr) <= 90 < max_in_col(lon_attr):
                     break
-    if not lon_attr:
-        for attr in all_vars:
-            if attr.is_continuous and attr is not lat_attr:
-                values = np.nan_to_num(
-                    data.get_column_view(attr)[0].astype(float))
-                if _all_between(values, -180, 180):
-                    lon_attr = attr
-                    break
+            if max_in_col(lon_attr) > 180:
+                lat_attr = lon_attr = cont_vars[0]
+    else:
+        lat_attr = lon_attr = cont_vars[0]
 
     return lat_attr, lon_attr

--- a/orangecontrib/geo/utils.py
+++ b/orangecontrib/geo/utils.py
@@ -6,6 +6,10 @@ from Orange.data import Table
 from Orange.data.domain import filter_visible
 
 
+LATITUDE_NAMES = ('latitude', 'lat')
+LONGITUDE_NAMES = ('longitude', 'lng', 'long', 'lon')
+
+
 def find_lat_lon(data, filter_hidden=False, fallback=True):
     """Return inferred latitude and longitude attributes as found in the data domain"""
     assert isinstance(data, Table)
@@ -17,11 +21,11 @@ def find_lat_lon(data, filter_hidden=False, fallback=True):
     lat_attr = next(
         (attr for attr in all_vars
          if attr.is_continuous and
-         attr.name.lower().startswith(('latitude', 'lat'))), None)
+         attr.name.lower().startswith(LATITUDE_NAMES)), None)
     lon_attr = next(
         (attr for attr in all_vars
          if attr.is_continuous and
-         attr.name.lower().startswith(('longitude', 'lng', 'long', 'lon'))),
+         attr.name.lower().startswith(LONGITUDE_NAMES)),
         None)
 
     if not fallback:

--- a/orangecontrib/geo/widgets/owgeotransform.py
+++ b/orangecontrib/geo/widgets/owgeotransform.py
@@ -115,14 +115,14 @@ class OWGeoTransform(OWWidget):
 
     def init_attr_values(self):
         model = self.variable_model
-
         model.set_domain(self.data.domain if self.data else None)
         self.Error.no_lat_lon_vars.clear()
 
         if model.rowCount() < 2:
-            self.Error.no_lat_lon_vars()
             lat, lon = None, None
-            self.data = None
+            if self.data:
+                self.Error.no_lat_lon_vars()
+                self.data = None
         else:
             lat, lon = find_lat_lon(
                 self.data, filter_hidden=True, fallback=False)

--- a/orangecontrib/geo/widgets/owgeotransform.py
+++ b/orangecontrib/geo/widgets/owgeotransform.py
@@ -114,10 +114,12 @@ class OWGeoTransform(OWWidget):
                                         self.apply)
 
     def init_attr_values(self):
-        self.variable_model.set_domain(self.data.domain if self.data else None)
+        model = self.variable_model
+
+        model.set_domain(self.data.domain if self.data else None)
         self.Error.no_lat_lon_vars.clear()
 
-        if self.variable_model.rowCount() < 2:
+        if model.rowCount() < 2:
             self.Error.no_lat_lon_vars()
             lat, lon = None, None
             self.data = None
@@ -125,7 +127,18 @@ class OWGeoTransform(OWWidget):
             lat, lon = find_lat_lon(
                 self.data, filter_hidden=True, fallback=False)
             if lat is None or lon is None:
-                lat, lon = self.variable_model[:2]
+                if model.rowCount() > 2:
+                    # Otherwise, use the same variable to make it evident that
+                    # this has to be set manually
+                    lat = lon = self.variable_model[0]
+                elif lat is not None:
+                    lon = model[lat == model[0]]
+                elif lon is not None:
+                    lat = model[lon == model[0]]
+                else:
+                    # Use the two you have; assuming the order is likely to be
+                    # lat / long, this is likely correct
+                    lat, lon = model[:2]
 
         self.attr_lat, self.attr_lon = lat, lon
 

--- a/orangecontrib/geo/widgets/owgeotransform.py
+++ b/orangecontrib/geo/widgets/owgeotransform.py
@@ -18,7 +18,8 @@ from Orange.widgets.utils.signals import Input, Output
 from Orange.data import ContinuousVariable, Table, Domain
 from Orange.data.util import get_unique_names, SharedComputeValue
 
-from orangecontrib.geo.utils import find_lat_lon
+from orangecontrib.geo.utils import \
+    find_lat_lon, LATITUDE_NAMES, LONGITUDE_NAMES
 
 
 def get_projections():
@@ -158,7 +159,12 @@ class OWGeoTransform(OWWidget):
         if self.replace_original:
             self.report_data.transf_names = None
         else:
-            # If appending, use the same names, just with numbers for uniqueness
+            # If names wouldn't be recognized in following widgets,
+            # replace with defaults
+            if not (names[0].lower().startswith(LATITUDE_NAMES) and
+                    names[1].lower().startswith(LONGITUDE_NAMES)):
+                names = ("latitude", "longitude")
+
             existing = [v.name for v in chain(dom.variables, dom.metas)]
             names = get_unique_names(existing, names)
             self.report_data.transf_names = tuple(names)

--- a/orangecontrib/geo/widgets/owgeotransform.py
+++ b/orangecontrib/geo/widgets/owgeotransform.py
@@ -114,31 +114,15 @@ class OWGeoTransform(OWWidget):
                                         self.apply)
 
     def init_attr_values(self):
-        model = self.variable_model
-        model.set_domain(self.data.domain if self.data else None)
         self.Error.no_lat_lon_vars.clear()
+        self.variable_model.set_domain(self.data.domain if self.data else None)
 
-        if model.rowCount() < 2:
-            lat, lon = None, None
-            if self.data:
+        lat, lon = None, None
+        if self.data:
+            lat, lon = find_lat_lon(self.data, filter_hidden=True)
+            if not (lat and lon):
                 self.Error.no_lat_lon_vars()
                 self.data = None
-        else:
-            lat, lon = find_lat_lon(
-                self.data, filter_hidden=True, fallback=False)
-            if lat is None or lon is None:
-                if model.rowCount() > 2:
-                    # Otherwise, use the same variable to make it evident that
-                    # this has to be set manually
-                    lat = lon = self.variable_model[0]
-                elif lat is not None:
-                    lon = model[lat == model[0]]
-                elif lon is not None:
-                    lat = model[lon == model[0]]
-                else:
-                    # Use the two you have; assuming the order is likely to be
-                    # lat / long, this is likely correct
-                    lat, lon = model[:2]
 
         self.attr_lat, self.attr_lon = lat, lon
 

--- a/orangecontrib/geo/widgets/tests/test_owgeotransform.py
+++ b/orangecontrib/geo/widgets/tests/test_owgeotransform.py
@@ -172,62 +172,6 @@ class TestOWGeoTransform(WidgetTest):
         np.testing.assert_almost_equal(conv[:, 1], out.metas[:, 1])
         np.testing.assert_equal(B[:, 2:], out.metas[:, 2:])
 
-    def test_coord_detection(self):
-        def use(*attrs):
-            data = Table.from_numpy(Domain(attrs), np.arange(12).reshape(3, 4))
-            self.send_signal(self.widget.Inputs.data, data)
-
-        def coords():
-            return self.widget.attr_lat, self.widget.attr_lon
-
-        self.widget.openContext = Mock()  # prevent remembering from prev test
-        self.widget.apply = Mock()  # just efficiency
-
-        d1, d2 = [DiscreteVariable(n, values=tuple(str(i) for i in range(6)))
-                  for n in ("d1", "d2")]
-        c1, c2, c3, lat, lon = [ContinuousVariable(n)
-                                for n in "c1 c2 c3 lat lon".split()]
-
-        # match names
-        use(c1, lon, lat, c2)
-        self.assertEqual(coords(), (lat, lon))
-        use(d1, lon, lat, d2)
-        self.assertEqual(coords(), (lat, lon))
-
-        # two numeric variables; one is matched by name
-        use(d1, lon, c2, d2)
-        self.assertEqual(coords(), (c2, lon))
-
-        use(d1, c2, lon, d2)
-        self.assertEqual(coords(), (c2, lon))
-
-        use(d1, lat, c2, d2)
-        self.assertEqual(coords(), (lat, c2))
-
-        use(d1, c2, lat, d2)
-        self.assertEqual(coords(), (lat, c2))
-
-        # two numeric variables, none matched by name: use them
-        use(d1, c1, c2, d2)
-        self.assertEqual(coords(), (c1, c2))
-
-        # more than 2
-        use(d1, c1, c2, lat)
-        self.assertEqual(coords(), (c1, c1))
-
-        use(d1, lat, c1, c2)
-        self.assertEqual(coords(), (lat, lat))
-
-        use(d1, c1, c2, lon)
-        self.assertEqual(coords(), (c1, c1))
-
-        use(d1, lon, c1, c2)
-        self.assertEqual(coords(), (lon, lon))
-
-        use(d1, c3, c2, c1)
-        self.assertEqual(coords(), (c3, c3))
-
-
     @patch("pyproj.Transformer.itransform", new=lambda *_: np.zeros((10, 2)))
     def test_report(self):
         widget = self.widget

--- a/orangecontrib/geo/widgets/tests/test_owgeotransform.py
+++ b/orangecontrib/geo/widgets/tests/test_owgeotransform.py
@@ -48,6 +48,9 @@ class TestOWGeoTransform(WidgetTest):
         self.send_signal(self.widget.Inputs.data, short_iris)
         self.assertTrue(self.widget.Error.no_lat_lon_vars.is_shown())
 
+        self.send_signal(self.widget.Inputs.data, None)
+        self.assertFalse(self.widget.Error.no_lat_lon_vars.is_shown())
+
     def test_data_on_output(self):
         self.send_signal(self.widget.Inputs.data, self.india_data)
         self.widget.replace_original = False


### PR DESCRIPTION
##### Issue

Fixes #144.

##### Description of changes

I improved the logic for selecting the variables with coordinates.

- If there are matching names, that's it (`find_lat_lon`).
- Otherwise, if there are more than three, select the first one for both (diagonal indicates that this has to be set).
- If there are two and one has an appropriate name, the remaining one has to be the other variables.
- Otherwise, select these two and, assuming the order is likely to be lat/lon, this is likely correct.

It follows the discussion from #130, the new point is the penultimate.

@ajdapretnar, maybe we should move this logic to `find_lat_lon`?

##### Includes
- [X] Code changes
- [X] Tests