### PR TITLE
Geo Map: Show white labels on dark maps

### DIFF
--- a/orangecontrib/geo/widgets/plotutils.py
+++ b/orangecontrib/geo/widgets/plotutils.py
@@ -60,14 +60,12 @@ def tile2norm(x, y, zoom):
     return x / n, y / n
 
 
-_TileProvider = NamedTuple(
-    "_TileProvider", [
-        ("url", str),
-        ("attribution", str),
-        ("size", int),
-        ("max_zoom", int),
-    ]
-)
+class _TileProvider(NamedTuple):
+    url: str
+    attribution: str
+    size: int
+    max_zoom: int
+    dark: bool = False
 
 
 TILE_PROVIDERS = {
@@ -105,7 +103,8 @@ TILE_PROVIDERS = {
         url="http://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
         attribution='&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>',
         size=256,
-        max_zoom=19
+        max_zoom=19,
+        dark=True
     ),
 }
 
@@ -200,6 +199,9 @@ class MapViewBox(InteractiveViewBox):
         zx = int(np.floor(np.log2(dx_tiles / dx)))
         zy = int(np.floor(np.log2(dy_tiles / dy)))
         self.__zoom_level = self.__clipped_zoom(min(zx, zy))
+
+    def tile_provider(self):
+        return self.__tile_provider
 
     def set_tile_provider(self, tp):
         self.__tile_provider = tp

--- a/orangecontrib/geo/widgets/tests/test_owmap.py
+++ b/orangecontrib/geo/widgets/tests/test_owmap.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 from AnyQt.QtCore import Qt
+from AnyQt.QtGui import QColor, QPalette
 
 import numpy as np
 from pyqtgraph import Point
@@ -14,6 +15,7 @@ from Orange.widgets.tests.base import (
     WidgetTest, WidgetOutputsTestMixin, ProjectionWidgetTestMixin
 )
 from orangecontrib.geo.widgets.owmap import OWMap, OWScatterPlotMapGraph
+from orangecontrib.geo.widgets.plotutils import TILE_PROVIDERS
 
 
 class TestOWMap(WidgetTest, ProjectionWidgetTestMixin, WidgetOutputsTestMixin):
@@ -50,6 +52,32 @@ class TestOWMap(WidgetTest, ProjectionWidgetTestMixin, WidgetOutputsTestMixin):
 
         self.assertTrue(self.widget.Warning.out_of_range.is_shown())
         self.assertEqual(np.sum(self.widget.valid_data), 1)
+
+    def test_label_colors(self):
+        widget = self.widget
+        self.send_signal(widget.Inputs.data, self.data)
+
+        # Pick any
+        for key, provider in TILE_PROVIDERS.items():
+            if provider.dark:
+                dark = key
+            else:
+                bright = key
+
+        white = QColor(Qt.white)
+        palette = widget.graph.plot_widget.palette
+
+        widget.graph.tile_provider_key = dark
+        widget.update_tile_provider()
+        self.assertEqual(palette().color(QPalette.Text), white)
+
+        widget.graph.tile_provider_key = bright
+        widget.update_tile_provider()
+        self.assertNotEqual(palette().color(QPalette.Text), white)
+
+        widget.graph.tile_provider_key = dark
+        widget.update_tile_provider()
+        self.assertEqual(palette().color(QPalette.Text), white)
 
     def test_send_report(self):
         self.send_signal(self.widget.Inputs.data, self.data)


### PR DESCRIPTION
##### Issue

Fixes #87.

##### Description of changes

- Add `dark` flag to description of tile providers.
- When the map is dark, set the color for Text role to white.

##### Includes
- [X] Code changes
- [X] Tests
