### PR TITLE
[FIX] Replace deprecated colorpalette with colorpalettes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2016]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
         python-version: [3.7, 3.8, 3.9]
         tox_env: [py-orange-released]
         experimental: [false]
         name: [Released]
         include:
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.8
             tox_env: py-orange-released
             experimental: true
@@ -34,7 +34,7 @@ jobs:
             experimental: true
             name: Big Sur
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.7
             tox_env: py-orange-oldest
             experimental: false
@@ -50,7 +50,7 @@ jobs:
             name: Oldest
             experimental: false
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.8
             tox_env: py-orange-latest
             experimental: false
@@ -66,7 +66,7 @@ jobs:
             experimental: false
             name: Latest
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.9
             tox_env: py-orange-latest
             experimental: false

--- a/orangecontrib/geo/widgets/tests/test_owmap.py
+++ b/orangecontrib/geo/widgets/tests/test_owmap.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest.mock import Mock
 
 from AnyQt.QtCore import Qt
@@ -9,8 +10,10 @@ from pyqtgraph import Point
 from Orange.data import Table,  Domain, ContinuousVariable
 from Orange.widgets.widget import OWWidget
 from Orange.widgets.settings import SettingProvider
-from Orange.widgets.utils.colorpalette import ColorPaletteGenerator, \
-    ContinuousPaletteGenerator
+from Orange.widgets.utils.colorpalettes import (
+    DefaultContinuousPalette,
+    LimitedDiscretePalette,
+)
 from Orange.widgets.tests.base import (
     WidgetTest, WidgetOutputsTestMixin, ProjectionWidgetTestMixin
 )
@@ -109,9 +112,9 @@ class MockWidget(OWWidget):
 
     def get_palette(self):
         if self.is_continuous_color():
-            return ContinuousPaletteGenerator(Qt.white, Qt.black, False)
+            return DefaultContinuousPalette
         else:
-            return ColorPaletteGenerator(12)
+            return LimitedDiscretePalette(12)
 
 
 class TestOWScatterPlotMapGraph(WidgetTest):
@@ -163,3 +166,7 @@ class TestOWScatterPlotMapGraph(WidgetTest):
         self.graph.reset_graph()
         self.graph.clear_map.assert_not_called()
         self.graph.update_view_range.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,9 @@ deps =
     oldest: orange-canvas-core==0.1.15 ; sys_platform == 'win32'
     oldest: orange-widget-base==4.5.0 ; sys_platform != 'win32'
     oldest: orange-widget-base==4.9.0 ; sys_platform == 'win32'
-    latest: git+git://github.com/biolab/orange3.git#egg=orange3
-    latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
-    latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base
+    latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
+    latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
+    latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
 commands_pre =
     # Verify installed packages have compatible dependencies
     pip check


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`colorpalette` module is deprecated and we wanted to remove it from Orange: https://github.com/biolab/orange3/pull/6135

##### Description of changes
Use classes from `colorpalettes` module instead

##### Includes
- [ ] Code changes
- [x] Tests
- [ ] Documentation
