### PR TITLE
Geo Coding: Replace obsolete call to setResizeMode

### DIFF
--- a/orangecontrib/geo/widgets/owgeocoding.py
+++ b/orangecontrib/geo/widgets/owgeocoding.py
@@ -165,7 +165,7 @@ class OWGeocoding(widget.OWWidget):
                              sortingEnabled=False,
                              selectionMode=gui.TableView.NoSelection,
                              editTriggers=gui.TableView.AllEditTriggers)
-        view.horizontalHeader().setResizeMode(QHeaderView.Stretch)
+        view.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         view.verticalHeader().setSectionResizeMode(0)
         view.setMinimumWidth(500)
         view.setModel(model)


### PR DESCRIPTION
Fixes #152.

`setResizeMode` was removed some time after Qt 5.12 and has to be replaced with `setSectionResizeMode`.

##### Includes
- [X] Code changes
