### PR TITLE
Utils: give lat and lon candidates as list from split string

### DIFF
--- a/orangecontrib/geo/utils.py
+++ b/orangecontrib/geo/utils.py
@@ -13,8 +13,8 @@ from Orange.data.domain import filter_visible
 
 T = TypeVar("T")
 
-LATITUDE_NAMES = ('latitude', 'lat')
-LONGITUDE_NAMES = ('longitude', 'lng', 'long', 'lon')
+LATITUDE_NAMES = tuple('latitude, lat'.split(", "))
+LONGITUDE_NAMES = tuple('longitude, lng, long, lon'.split(", "))
 
 
 def find_lat_lon(data, filter_hidden=False):


### PR DESCRIPTION
##### Issue

When translating into other languages, one can't add new candidate names for latitude and longitude without removing the existing.

##### Description of changes

Define the candidates as a string that is then split into names. This allows for arbitrary number of names.

##### Includes
- [X] Code changes
