### PR TITLE
[FIX] Choropleth: Store selection by region ids, not indices

### DIFF
--- a/orangecontrib/geo/widgets/tests/test_owchoropleth.py
+++ b/orangecontrib/geo/widgets/tests/test_owchoropleth.py
@@ -122,5 +122,44 @@ class TestOWChoropleth(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.data, self.data)
 
 
+class TestOWChoroplethPlotGraph(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        WidgetOutputsTestMixin.init(cls)
+        cls.same_input_output_domain = False
+        cls.signal_name = "Data"
+
+    @patch("orangecontrib.geo.widgets.plotutils.ImageLoader")
+    def setUp(self, _):
+        self.widget = self.create_widget(OWChoropleth)
+        self.widget.admin_level = 1
+        data = self.data = Table("India_census_district_population")
+        self.send_signal(self.widget.Inputs.data, data)
+        self.graph = self.widget.graph
+
+    def test_set_get_selection_by_ids(self):
+        selection = list(zip(self.widget.region_ids[[1, 3, 4]], [1, 1, 2]))
+        self.graph.set_selection_from_ids(selection)
+        np.testing.assert_equal(self.graph.selection[:6], [0, 1, 0, 1, 2, 0])
+        self.assertEqual(self.graph.selected_ids(), selection)
+
+        selection.append(("foo", 1))
+        selection.pop(0)
+        self.graph.set_selection_from_ids(selection)
+        np.testing.assert_equal(self.graph.selection[:6], [0, 0, 0, 1, 2, 0])
+        self.assertEqual(self.graph.selected_ids(), selection[:2])
+
+        self.graph.set_selection_from_ids([])
+        self.assertFalse(np.any(self.graph.selection))
+        self.assertEqual(self.graph.selected_ids(), [])
+
+        self.graph.set_selection_from_ids(selection)
+        np.testing.assert_equal(self.graph.selection[:6], [0, 0, 0, 1, 2, 0])
+        self.graph.set_selection_from_ids(None)
+        self.assertFalse(np.any(self.graph.selection))
+        self.assertEqual(self.graph.selected_ids(), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue

Fixes #163.

##### Description of changes

Widget now stores selection by region ids, not indices. When selection is restored, missing region ids are ignored.

##### Includes
- [X] Code changes
- [X] Tests
