### PR TITLE
Keywords: changed from list to string

### DIFF
--- a/doc/widgets.json
+++ b/doc/widgets.json
@@ -7,21 +7,32 @@
     "doc": "widgets/geocoding.md",
     "icon": "../orangecontrib/geo/widgets/icons/Geocoding.svg",
     "background": "#a0eaa0",
-    "keywords": []
+    "keywords": [
+     "geocoding",
+     "geo",
+     "coding"
+    ]
    },
    {
     "text": "Geo Map",
     "doc": "widgets/geomap.md",
     "icon": "../orangecontrib/geo/widgets/icons/GeoMap.svg",
     "background": "#a0eaa0",
-    "keywords": []
+    "keywords": [
+     "geo map",
+     "map",
+     "geo"
+    ]
    },
    {
     "text": "Choropleth Map",
     "doc": "widgets/choroplethmap.md",
     "icon": "../orangecontrib/geo/widgets/icons/Choropleth.svg",
     "background": "#a0eaa0",
-    "keywords": []
+    "keywords": [
+     "choropleth map",
+     "geo"
+    ]
    },
    {
     "text": "Geo Transform",
@@ -29,6 +40,7 @@
     "icon": "../orangecontrib/geo/widgets/icons/GeoTransform.svg",
     "background": "#a0eaa0",
     "keywords": [
+     "geo transform",
      "transform",
      "geo"
     ]

--- a/orangecontrib/geo/widgets/owchoropleth.py
+++ b/orangecontrib/geo/widgets/owchoropleth.py
@@ -616,11 +616,12 @@ class OWChoropleth(OWWidget):
     `OWChoroplethPlotGraph` is to `OWScatterPlotBase`.
     """
 
-    name = 'Choropleth Map'
+    name = "Choropleth Map"
     description = 'A thematic map in which areas are shaded in proportion ' \
                   'to the measurement of the statistical variable being displayed.'
     icon = "icons/Choropleth.svg"
     priority = 120
+    keywords = "choropleth map, geo"
 
     class Inputs:
         data = Input("Data", Table, default=True)

--- a/orangecontrib/geo/widgets/owgeocoding.py
+++ b/orangecontrib/geo/widgets/owgeocoding.py
@@ -30,11 +30,12 @@ def guess_region_attr_name(data):
 
 
 class OWGeocoding(widget.OWWidget):
-    name = 'Geocoding'
+    name = "Geocoding"
     description = 'Encode region names into geographical coordinates, or ' \
                   'reverse-geocode latitude and longitude pairs into regions.'
     icon = "icons/Geocoding.svg"
     priority = 40
+    keywords = "geocoding, geo, coding"
 
     class Inputs:
         data = Input("Data", Table, default=True)

--- a/orangecontrib/geo/widgets/owgeotransform.py
+++ b/orangecontrib/geo/widgets/owgeotransform.py
@@ -62,7 +62,7 @@ class OWGeoTransform(OWWidget):
     description = "Transform geographic coordinates from one system to another."
     icon = "icons/GeoTransform.svg"
     priority = 320
-    keywords = ["transform", "geo"]
+    keywords = "geo transform, transform, geo"
 
     class Inputs:
         data = Input("Data", Table)

--- a/orangecontrib/geo/widgets/owmap.py
+++ b/orangecontrib/geo/widgets/owmap.py
@@ -98,10 +98,11 @@ class OWMap(OWDataProjectionWidget):
     background.
     """
 
-    name = 'Geo Map'
+    name = "Geo Map"
     description = 'Show data points on a world map.'
     icon = "icons/GeoMap.svg"
     priority = 100
+    keywords = "geo map, map, geo"
 
     replaces = [
         "Orange.widgets.visualize.owmap.OWMap",


### PR DESCRIPTION
##### Issue

Keywords were given in lists, so translations had to have the same number of keywords (or less - but not more).

##### Description of changes

Now they are written in string.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
