### PR TITLE
Add category name and description

### DIFF
--- a/orangecontrib/geo/widgets/__init__.py
+++ b/orangecontrib/geo/widgets/__init__.py
@@ -1,5 +1,8 @@
 # Category metadata.
 
+NAME = "Geo"
+DESCRIPTION = "Transformation and visualization of geographical data."
+
 # Category icon show in the menu
 ICON = "icons/category.svg"
 


### PR DESCRIPTION
##### Issue

- Name is currently deduced from entry point name in setup.py. This is not translatable.
- Description (show as tooltip) is missing.

##### Description of changes

Add `NAME` (same as before, `"Geo"`) and `DESCRIPTION` to category globals.

##### Includes
- [X] Code changes
