### PR TITLE
Require Orange 3.34

### DIFF
--- a/orangecontrib/geo/__init__.py
+++ b/orangecontrib/geo/__init__.py
@@ -1,23 +1,6 @@
 from os.path import join, dirname
 from Orange.data.table import dataset_dirs
-from Orange.data import Table
 
 
 dataset_dirs.insert(0, join(dirname(__file__), "datasets"))
 del join, dirname, dataset_dirs
-
-
-# Remove this when we require Orange 3.34
-if not hasattr(Table, "get_column"):
-    import scipy.sparse as sp
-    import numpy as np
-
-    def get_column(self, column):
-        col, _ = self.get_column_view(column)
-        if sp.issparse(col):
-            col = col.toarray().reshape(-1)
-        if self.domain[column].is_primitive():
-            col = col.astype(np.float64)
-        return col
-
-    Table.get_column = get_column

--- a/orangecontrib/geo/tests/test_utils.py
+++ b/orangecontrib/geo/tests/test_utils.py
@@ -99,17 +99,5 @@ class TestUtils(TestCase):
         self.assertEqual(attrs_for(d1, c3, c2, c1), (c3, c3))
 
 
-class TestDeprecations(unittest.TestCase):
-    def test_remove_get_column_workaround(self):
-        """
-        When this tests start to fail:
-        1. remove this test
-        2. set minimum version of Orange to 3.34 if not set yet
-        3. remove workaround from __inint__.py
-        """
-        from datetime import datetime
-        self.assertLess(datetime.today(), datetime(2024, 1, 1))
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
         packages=find_packages(),
         include_package_data=True,
         install_requires=[
-            'Orange3>=3.31.0',
+            'Orange3>=3.34.0',
             'scikit-learn',
             'pandas',
             'scipy>=0.17',

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
 deps =
     {env:PYQT_PYPI_NAME:PyQt5}=={env:PYQT_PYPI_VERSION:5.15.*}
     {env:WEBENGINE_PYPI_NAME:PyQtWebEngine}=={env:WEBENGINE_PYPI_VERSION:5.15.*}
-    oldest: numpy~=1.21.0  # some older version
+    oldest: numpy~=1.22.0  # some older version
     oldest: orange3==3.34.0
     oldest: orange-canvas-core==0.1.28
     oldest: orange-widget-base==4.19.0

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,12 @@ setenv =
 deps =
     {env:PYQT_PYPI_NAME:PyQt5}=={env:PYQT_PYPI_VERSION:5.15.*}
     {env:WEBENGINE_PYPI_NAME:PyQtWebEngine}=={env:WEBENGINE_PYPI_VERSION:5.15.*}
+    oldest: numpy~=1.21.0  # some older version
     oldest: orange3==3.34.0
+    oldest: orange-canvas-core==0.1.28
+    oldest: orange-widget-base==4.19.0
     oldest: pandas==1.4.0
+    oldest: scikit-learn~=1.0.1
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base

--- a/tox.ini
+++ b/tox.ini
@@ -22,11 +22,8 @@ setenv =
 deps =
     {env:PYQT_PYPI_NAME:PyQt5}=={env:PYQT_PYPI_VERSION:5.15.*}
     {env:WEBENGINE_PYPI_NAME:PyQtWebEngine}=={env:WEBENGINE_PYPI_VERSION:5.15.*}
-    oldest: scikit-learn~=0.23.1
-    oldest: numpy~=1.21.0  # some older version
-    oldest: orange3==3.31.0
-    oldest: orange-canvas-core==0.1.24
-    oldest: orange-widget-base==4.16.1
+    oldest: orange3==3.34.0
+    oldest: pandas==1.4.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
##### Issue

As decided when we added a workaround for `Table.get_column`, the time arrived to require Orange 3.34 and remove the workaround (and defuse the time bomb).