### PR TITLE
Mapper: Remove deprecated function

### DIFF
--- a/orangecontrib/geo/mapper.py
+++ b/orangecontrib/geo/mapper.py
@@ -23,35 +23,11 @@ from orangecontrib.geo.utils import once
 log = logging.getLogger(__name__)
 
 
-def is_shapely_speedups_available():
-    if not shapely.speedups.available:
-        return False
-    # Otherwise try shapely with speedups in a subprocess to see if shit
-    # is crash due to ABI-incompatible libgeos found in path on Loonix
-    import sys, subprocess
-    proc = subprocess.Popen(
-        sys.executable + ' -c ' + '''"import json
-from shapely.geometry import shape
-import shapely.speedups
-shapely.speedups.enable()
-shape(json.load(open('%s'))['features'][0]['geometry'])
-"''' % path.join(GEOJSON_DIR, 'admin0.json'),
-        # Didn't return correct exit status without shell=True
-        shell=True)
-    proc.wait()
-    return proc.returncode == 0
-
-
 GEOJSON_DIR = path.join(path.dirname(__file__), 'geojson')
 
 ADMIN2_COUNTRIES = {path.basename(filename).split('.')[0].split('-')[1]
                     for filename in glob(path.join(GEOJSON_DIR, 'admin2-*.json'))}
 NUL = {}  # nonmapped (invalid) output region
-
-
-if is_shapely_speedups_available():
-    shapely.speedups.enable()
-    log.debug('Shapely speed-ups available')
 
 
 def wait_until_loaded(func):

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
             'scikit-learn',
             'pandas',
             'scipy>=0.17',
-            'shapely',
+            'shapely>=2',
             'pyproj',
             'simplejson',
             'Pillow'


### PR DESCRIPTION
##### Issue

Previously, we needed to enabled cython-based speedups in Shapely. Starting with Shapely 2.0, equivalent speedups are available in every installation. Function `enable` has no effect and will be removed in future versions, they say.

##### Description of changes

- Remove the code that checks whether speedups are available and enables them.
- Require Shapely>=2

##### Includes
- [X] Code changes
