### PR TITLE
Remove unavailable tile providers, add some new

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -1377,20 +1377,20 @@ widgets/plotutils.py:
     OpenStreetMap: false
     http://tile.openstreetmap.org/{z}/{x}/{y}.png: false
     &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>: false
-    Black and white: Črno-bel
-    http://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png: false
+    Greyscale: Sivinski
+    http://tile.geofabrik.de/c92f820ec8abcfd7f51b075e3efa157e//{z}/{x}/{y}.png: false
+    <a href="http://geofabrik.di">Geofabrik</a>: false
     Topographic: Topografski
     http://tile.opentopomap.org/{z}/{x}/{y}.png: false
     'map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)': false
     Satellite: Satelitski
     http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}: false
     'Sources: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AeroGRID, IGN, and the GIS User Community': false
-    Print: Tisk
-    http://tile.stamen.com/toner/{z}/{x}/{y}.png: false
-    Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.: false
+    Light: Svetel
+    http://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png: false
+    &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>: false
     Dark: Temen
     http://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png: false
-    &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>: false
     class `MapViewBox`:
         def `mouseDragEvent`:
             mouseMode: false

--- a/orangecontrib/geo/widgets/plotutils.py
+++ b/orangecontrib/geo/widgets/plotutils.py
@@ -75,11 +75,11 @@ TILE_PROVIDERS = {
         size=256,
         max_zoom=18
     ),
-    "Black and white": _TileProvider(
-        url="http://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png",
-        attribution='&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+    "Greyscale": _TileProvider(
+        url="http://tile.geofabrik.de/c92f820ec8abcfd7f51b075e3efa157e//{z}/{x}/{y}.png",
+        attribution='<a href="http://geofabrik.di">Geofabrik</a>',
         size=256,
-        max_zoom=18
+        max_zoom=19
     ),
     "Topographic": _TileProvider(
         url="http://tile.opentopomap.org/{z}/{x}/{y}.png",
@@ -93,11 +93,11 @@ TILE_PROVIDERS = {
         size=256,
         max_zoom=19
     ),
-    "Print": _TileProvider(
-        url="http://tile.stamen.com/toner/{z}/{x}/{y}.png",
-        attribution='Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+    "Light": _TileProvider(
+        url="http://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+        attribution='&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>',
         size=256,
-        max_zoom=20
+        max_zoom=19
     ),
     "Dark": _TileProvider(
         url="http://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",


### PR DESCRIPTION
##### Issue

Several tile providers went commercial or ceased to work.

Fixes #188, fixes #173.

##### Description of changes

Remove Mapnik and Stamen, add Greyscale from Geofabrik and Light from Carto.

Here's an interesting site to find alternative providers: https://mc.bbbike.org/mc/. Note, though, that most of them require an API_KEY and are thus not suitable for our use.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
