### PR TITLE
Choropleth Map: Use variable palette, when given

### DIFF
--- a/orangecontrib/geo/widgets/owchoropleth.py
+++ b/orangecontrib/geo/widgets/owchoropleth.py
@@ -28,6 +28,7 @@ from Orange.statistics.util import bincount
 from Orange.preprocess.discretize import decimal_binnings, BinDefinition,\
     time_binnings
 from Orange.widgets import gui
+from Orange.widgets.utils import colorpalettes
 from Orange.widgets.utils.annotated_data import create_annotated_table, \
     ANNOTATED_DATA_SIGNAL_NAME, create_groups_table
 from Orange.widgets.utils.plot import OWPlotGUI
@@ -904,10 +905,15 @@ class OWChoropleth(OWWidget):
     def get_palette(self):
         if self.agg_func in COUNT_AGGS:
             return DefaultContinuousPalette
-        elif self.is_mode():
-            return LimitedDiscretePalette(MAX_COLORS)
-        else:
-            return self.agg_attr.palette
+        attr = self.agg_attr
+        palette = attr.palette
+        if self.is_mode():
+            labels = self.get_reduced_agg_data(return_labels=True)
+            if labels != attr.values:
+                colors = [palette.palette[attr.to_val(label)]
+                          for label in labels[:-1]] + [[192, 192, 192]]
+                palette = colorpalettes.DiscretePalette.from_colors(colors)
+        return palette
 
     def get_color_data(self):
         return self.get_reduced_agg_data()

--- a/orangecontrib/geo/widgets/tests/test_owchoropleth.py
+++ b/orangecontrib/geo/widgets/tests/test_owchoropleth.py
@@ -1,11 +1,13 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 import numpy as np
 
 from AnyQt.QtCore import QRectF, QPointF
 
-from Orange.data import Table, Domain
+from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
+from Orange.misc.cache import memoize_method
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
+from Orange.widgets.utils.colorpalettes import DefaultContinuousPalette
 from Orange.widgets.visualize.owscatterplotgraph import SymbolItemSample
 from orangecontrib.geo.widgets.owchoropleth import OWChoropleth, \
     BinningPaletteItemSample, DEFAULT_AGG_FUNC
@@ -120,6 +122,54 @@ class TestOWChoropleth(WidgetTest, WidgetOutputsTestMixin):
             self.data.X[:] = np.nan
 
         self.send_signal(self.widget.Inputs.data, self.data)
+
+    def test_get_palette(self):
+        self.widget.get_regions = memoize_method(3)(
+            lambda *_: (np.arange(26), [{}] * 26, [[]] * 26))
+        self.widget.setup_plot = Mock()
+
+        a, b = (
+            DiscreteVariable("a", values=("a", "b")),
+            DiscreteVariable("b", values=tuple("abcdefghijklm")))
+        d = Domain(
+            [a, b],
+            [],
+            [ContinuousVariable("latitude"),
+             ContinuousVariable("longitude")])
+        # 0 and 3 appear only once, 13 doesn't appear at all
+        data = Table.from_numpy(
+            d,
+            np.array([[0, 1] * 13,
+                      [1, 2, 4, 5, 6, 7, 8, 9, 8, 9, 10, 10, 12,
+                       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],]).T,
+            None,
+            np.arange(45, 97).reshape(2, 26).T
+        )
+        self.send_signal(self.widget.Inputs.data, data)
+
+        self.widget.agg_attr = data.domain["a"]
+        self.widget.agg_func = "Mode"
+        np.testing.assert_equal(
+            self.widget.get_palette().palette,
+            a.palette.palette)
+        self.widget.agg_func = "Instance Count"
+        self.assertIs(
+            self.widget.get_palette(),
+            DefaultContinuousPalette)
+
+        self.widget.agg_attr = data.domain["b"]
+        self.widget.get_agg_data()
+        self.assertIs(
+            self.widget.get_palette(),
+            DefaultContinuousPalette)
+        self.widget.agg_func = "Mode"
+        self.widget.graph.update_colors()
+        self.widget.get_agg_data()
+        palette = self.widget.get_palette().palette
+        np.testing.assert_equal(
+            palette[:-1],
+            b.palette.palette[[1, 2, 4, 5, 6, 7, 8, 9, 10, 12]])
+        np.testing.assert_equal(palette[-1], [192, 192, 192])
 
 
 class TestOWChoroplethPlotGraph(WidgetTest):


### PR DESCRIPTION
##### Issue

Choropleth (explicitly) overrode the variable's palette when the aggregation was set to Mode. 

Fixes #177.

##### Description of changes

I don't know see the reason for this overriding, so I removed it.

To match the defined colors, we must also take into account that categorical values can be merged, thence the new code.

Tests call some widget's method to update the internal attributes. This widget is difficult to mock.

##### Includes
- [X] Code changes
- [X] Tests
